### PR TITLE
Add REPL-based learning mode using ReplMaker backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ authors = ["Swirl.jl Contributors"]
 version = "0.1.0"
 
 [deps]
-REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
+ReplMaker = "0.2.7"
 julia = "1.6"

--- a/src/Swirl.jl
+++ b/src/Swirl.jl
@@ -3,9 +3,9 @@ module Swirl
 using REPL
 using Markdown
 using Serialization
+using ReplMaker
 
-export swirl, install_course, uninstall_course, list_courses, delete_progress,
-    reset_lesson_progress, reset_course_progress, list_progress, list_installed_courses
+export swirl, install_course, uninstall_course, list_courses, delete_progress
 
 # Core types
 include("types.jl")
@@ -14,134 +14,282 @@ include("parser.jl")
 include("runner.jl")
 include("courses.jl")
 
-"""
-    swirl()
-
-Start an interactive Swirl learning session. You'll be able to choose from
-available courses and lessons to learn Julia interactively.
-"""
-function swirl()
+# Try to load ReplMaker, but don't fail if it's not available
+const REPLMAKER_AVAILABLE = Ref(false)
+function __init__()
     try
-        while true  # Main loop to allow returning to menu
-            println("\n" * "="^60)
-            println("| Welcome to Swirl for Julia! 🌀")
-            println("="^60)
-            println()
+        @eval using ReplMaker
+        REPLMAKER_AVAILABLE[] = true
+    catch
+        REPLMAKER_AVAILABLE[] = false
+    end
+end
 
-            courses = get_available_courses()
+"""
+    swirl(; use_repl_mode=:auto)
 
-            if isempty(courses)
-                println("No courses installed yet!")
-                println("The basic 'Julia Basics' course will be installed for you.")
-                install_default_course()
-                courses = get_available_courses()
-            end
+Start an interactive Swirl learning session with full navigation.
+"""
+function swirl(; use_repl_mode::Symbol=:auto)
+    courses = get_available_courses()
 
-            # Course selection
-            println("Available courses:")
-            for (i, course) in enumerate(courses)
-                println("  $i. $(course.name)")
-            end
-            println("  0. Exit Swirl")
-            println()
+    if isempty(courses)
+        println("No courses installed yet!")
+        println("The basic 'Julia Basics' course will be installed for you.")
+        install_default_course()
+        courses = get_available_courses()
+    end
 
-            course_idx = get_user_choice("Select a course (enter number, or 0 to exit): ", 0:length(courses))
+    # Determine if we should use REPL mode
+    use_repl = if use_repl_mode == :auto
+        REPLMAKER_AVAILABLE[]
+    elseif use_repl_mode == :repl
+        if !REPLMAKER_AVAILABLE[]
+            error("ReplMaker mode requested but ReplMaker.jl is not available. Install with: using Pkg; Pkg.add(\"ReplMaker\")")
+        end
+        true
+    else  # :classic
+        false
+    end
 
-            if course_idx == 0
+    if use_repl
+        # Initialize REPL mode
+        if !REPL_MODE_INITIALIZED[]
+            ReplMaker.initrepl(
+                swirl_repl_handler;
+                repl=Base.active_repl,
+                prompt_text="swirl> ",
+                prompt_color=:cyan,
+                start_key=')',
+                mode_name="Swirl",
+                sticky_mode=true,
+                startup_text=true,
+                completion_provider=REPL.REPLCompletionProvider(),
+            )
+            REPL_MODE_INITIALIZED[] = true
+        end
+
+        # Set up course selection state
+        course_state = ReplCourseState(courses, true)
+        CURRENT_LESSON_STATE[] = course_state
+
+        # Display welcome and instructions
+        println("\n" * "="^60)
+        println("| Welcome to Swirl for Julia! 🌀")
+        println("="^60)
+        println()
+        println("🌀 Type ')' to enter Swirl mode!")
+        println("   (Press backspace anytime to exit Swirl mode)")
+        println()
+
+        # Display course menu
+        display_course_menu(courses)
+
+        return
+    else
+        # Classic (alternative) mode
+        println("\n" * "="^60)
+        println("| Welcome to Swirl for Julia! 🌀")
+        println("="^60)
+        println()
+
+        while true
+            selected_course = course_selection_menu(courses)
+            if selected_course === nothing
                 println("\n👋 Thanks for using Swirl! Happy coding!")
                 return
             end
-
-            selected_course = courses[course_idx]
-
-            # Lesson selection loop
-            while true
-                println("\nLessons in $(selected_course.name):")
-                for (i, lesson) in enumerate(selected_course.lessons)
-                    progress = get_lesson_progress(selected_course.name, lesson.name)
-                    status = progress.completed ? "✓" : " "
-                    println("  $i. [$status] $(lesson.name)")
-                end
-                println()
-                println("Commands:")
-                println("  0. Back to course selection")
-                println("  reset <number>. Reset/retake a specific lesson (e.g., 'reset 1')")
-                println("  reset all. Reset all lessons in this course")
-                println()
-
-                print("Select a lesson (enter number, command, or 0 to go back): ")
-                input = strip(readline())
-
-                # Check for reset commands
-                if lowercase(input) == "reset all"
-                    print("Are you sure you want to reset ALL lessons in this course? (yes/no): ")
-                    confirm = lowercase(strip(readline()))
-                    if confirm in ["yes", "y"]
-                        reset_course_progress(selected_course.name)
-                        println("✓ All lessons have been reset!")
-                        sleep(1)
-                    end
-                    continue
-                elseif startswith(lowercase(input), "reset ")
-                    # Extract lesson number
-                    try
-                        lesson_num_str = strip(replace(lowercase(input), "reset" => ""))
-                        lesson_num = parse(Int, lesson_num_str)
-                        if lesson_num >= 1 && lesson_num <= length(selected_course.lessons)
-                            lesson_name = selected_course.lessons[lesson_num].name
-                            reset_lesson_progress(selected_course.name, lesson_name)
-                            println("✓ Lesson '$(lesson_name)' has been reset!")
-                            sleep(1)
-                        else
-                            println("Invalid lesson number. Please try again.")
-                            sleep(1)
-                        end
-                    catch
-                        println("Invalid command. Use 'reset <number>' (e.g., 'reset 2')")
-                        sleep(1)
-                    end
-                    continue
-                end
-
-                # Check for exit command
-                if lowercase(input) in ["exit", "quit", "bye"]
-                    println("\n👋 Thanks for using Swirl! Happy coding!")
-                    return
-                end
-
-                # Try to parse as lesson selection
-                try
-                    lesson_idx = parse(Int, input)
-
-                    if lesson_idx == 0
-                        break  # Go back to course selection
-                    elseif lesson_idx >= 1 && lesson_idx <= length(selected_course.lessons)
-                        selected_lesson = selected_course.lessons[lesson_idx]
-
-                        # Run the lesson
-                        run_lesson(selected_course.name, selected_lesson)
-
-                        # After lesson completes or user exits, return to lesson menu
-                        println("\nReturning to lesson selection...")
-                        sleep(1)
-                    else
-                        println("Please enter a number between 0 and $(length(selected_course.lessons))")
-                        sleep(1)
-                    end
-                catch
-                    println("Invalid input. Please enter a number or command.")
-                    sleep(1)
-                end
+            repl_launched = lesson_selection_loop(selected_course, use_repl_mode)
+            if repl_launched
+                return
             end
         end
-    catch e
-        if e isa InterruptException
-            # User pressed Ctrl+C or typed 'exit' - return gracefully
-            return
-        else
-            # Some other error - rethrow it
-            rethrow(e)
+    end
+end
+
+"""
+    course_selection_menu(courses)
+
+Display course selection menu and return selected course or nothing to exit.
+"""
+function course_selection_menu(courses)
+    println("\nAvailable courses:")
+    for (i, course) in enumerate(courses)
+        println("  $i. $(course.name)")
+    end
+    println("  0. Exit Swirl")
+    println()
+
+    while true
+        print("Select a course (enter number, or 0 to exit): ")
+        input = strip(readline())
+
+        if input == "0"
+            return nothing
         end
+
+        try
+            choice = parse(Int, input)
+            if choice >= 1 && choice <= length(courses)
+                return courses[choice]
+            else
+                println("Please enter a number between 0 and $(length(courses))")
+            end
+        catch
+            println("Invalid input. Please enter a number.")
+        end
+    end
+end
+
+"""
+    lesson_selection_loop(course, use_repl_mode)
+
+Handle lesson selection, reset commands, and navigation within a course.
+"""
+function lesson_selection_loop(course, use_repl_mode)
+    while true
+        # Display lesson list
+        println("\n" * "="^60)
+        println("Lessons in $(course.name):")
+        println("="^60)
+        for (i, lesson) in enumerate(course.lessons)
+            progress = get_lesson_progress(course.name, lesson.name)
+            status = progress.completed ? "✓" : " "
+            println("  $i. [$status] $(lesson.name)")
+        end
+        println()
+        println("Commands:")
+        println("  0. Back to course selection")
+        println("  reset <number>. Reset/retake a specific lesson (e.g., 'reset 1')")
+        println("  reset all. Reset all lessons in this course")
+        println()
+
+        print("Select a lesson (enter number, command, or 0 to go back): ")
+        input = strip(readline())
+
+        # Handle input
+        if input == "0"
+            return false # Go back to course selection
+        elseif startswith(lowercase(input), "reset all")
+            handle_reset_all(course)
+            continue
+        elseif startswith(lowercase(input), "reset ")
+            handle_reset_lesson(course, input)
+            continue
+        end
+
+        # Try to parse as lesson number
+        try
+            lesson_idx = parse(Int, input)
+            if lesson_idx >= 1 && lesson_idx <= length(course.lessons)
+                selected_lesson = course.lessons[lesson_idx]
+
+                # Run the lesson
+                launched_repl_mode = run_lesson_with_mode(course.name, selected_lesson, use_repl_mode)
+
+                if launched_repl_mode
+                    return true
+                else
+                    # After lesson completes, loop back to lesson selection
+                    continue
+                end
+            else
+                println("Please enter a number between 0 and $(length(course.lessons))")
+            end
+        catch
+            println("Invalid input. Please enter a number or command.")
+        end
+    end
+end
+
+"""
+    handle_reset_lesson(course, input)
+
+Reset a specific lesson based on user input.
+"""
+function handle_reset_lesson(course, input)
+    # Parse lesson number from "reset 1", "reset 2", etc.
+    parts = split(input)
+    if length(parts) >= 2
+        try
+            lesson_num = parse(Int, parts[2])
+            if lesson_num >= 1 && lesson_num <= length(course.lessons)
+                lesson = course.lessons[lesson_num]
+
+                # Delete progress file
+                progress_file = get_progress_file(course.name, lesson.name)
+                if isfile(progress_file)
+                    rm(progress_file)
+                    println()
+                    println("✓ Reset lesson: $(lesson.name)")
+                else
+                    println()
+                    println("ℹ️  Lesson not started yet: $(lesson.name)")
+                end
+            else
+                println("Invalid lesson number. Enter a number between 1 and $(length(course.lessons))")
+            end
+        catch
+            println("Invalid format. Use: reset <number> (e.g., 'reset 1')")
+        end
+    else
+        println("Invalid format. Use: reset <number> (e.g., 'reset 1')")
+    end
+end
+
+"""
+    handle_reset_all(course)
+
+Reset all lessons in a course.
+"""
+function handle_reset_all(course)
+    print("Are you sure you want to reset ALL lessons in $(course.name)? (yes/no): ")
+    response = lowercase(strip(readline()))
+
+    if response == "yes" || response == "y"
+        count = 0
+        for lesson in course.lessons
+            progress_file = get_progress_file(course.name, lesson.name)
+            if isfile(progress_file)
+                rm(progress_file)
+                count += 1
+            end
+        end
+        println("✓ Reset $count lesson$(count == 1 ? "" : "s")")
+    else
+        println("Cancelled.")
+    end
+end
+
+"""
+    run_lesson_with_mode(course_name, lesson, use_repl_mode)
+
+Run a lesson in the appropriate mode.
+"""
+function run_lesson_with_mode(course_name, lesson, use_repl_mode)
+    # Determine which mode to use
+    use_repl = if use_repl_mode == :auto
+        REPLMAKER_AVAILABLE[]
+    elseif use_repl_mode == :repl
+        if !REPLMAKER_AVAILABLE[]
+            error("ReplMaker mode requested but ReplMaker.jl is not available. Install with: using Pkg; Pkg.add(\"ReplMaker\")")
+        end
+        true
+    else  # :classic
+        false
+    end
+
+    # Run the lesson
+    if use_repl
+        run_lesson_repl_mode(course_name, lesson)
+        return true
+    else
+        if use_repl_mode == :auto && !REPLMAKER_AVAILABLE[]
+            println("\n💡 Tip: Install ReplMaker.jl for syntax highlighting!")
+            println("   Run: using Pkg; Pkg.add(\"ReplMaker\")\n")
+        end
+        run_lesson_classic_mode(course_name, lesson)
+        return false
     end
 end
 
@@ -149,13 +297,6 @@ function get_user_choice(prompt::String, range::AbstractRange)
     while true
         print(prompt)
         input = readline()
-
-        # Allow 'exit' or 'quit' at any menu
-        if lowercase(strip(input)) in ["exit", "quit", "bye"]
-            println("\n👋 Thanks for using Swirl! Happy coding!")
-            throw(InterruptException())  # Signal to exit Swirl, but not Julia
-        end
-
         try
             choice = parse(Int, input)
             if choice in range

--- a/src/courses.jl
+++ b/src/courses.jl
@@ -402,9 +402,9 @@ end
 Create the built-in Julia Basics course with fundamental lessons.
 """
 function create_basic_julia_course()
-    # Lesson 1: Basic Math and Variables
+    # Lesson 1: Basic Math and Bindings
     lesson1 = Lesson(
-        "Basic Math and Variables",
+        "Basic Math and Bindings",
         "Learn basic arithmetic operations and how to create bindings in Julia.",
         [
             Question(

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,45 +1,18 @@
-# Improved code parsing and evaluation
+# Code parsing and evaluation
 
 """
     safe_eval(code_str)
 
 Safely evaluate a string of Julia code and return the result.
-For multi-statement code (separated by ; or newlines), returns the last result.
 """
-function safe_eval(code_str::String)
+function safe_eval(code_str::AbstractString)
+    code_str = String(code_str)
     try
-        # Parse the code - this might be multiple statements
+        # Parse the code
         expr = Meta.parse(code_str)
 
-        # Evaluate in Main module so bindings persist
+        # Evaluate in Main module so variables persist
         result = Core.eval(Main, expr)
-
-        return (success=true, result=result, error=nothing)
-    catch e
-        return (success=false, result=nothing, error=e)
-    end
-end
-
-"""
-    safe_eval_multi(code_str)
-
-Evaluate code that may contain multiple statements separated by semicolons or newlines.
-Returns the result of the LAST statement (like Julia REPL behavior).
-"""
-function safe_eval_multi(code_str::String)
-    try
-        # Check if there are multiple statements
-        # Split on semicolons and evaluate each
-        statements = split(code_str, ';')
-
-        local result = nothing
-        for stmt in statements
-            stmt_stripped = strip(stmt)
-            if !isempty(stmt_stripped)
-                expr = Meta.parse(stmt_stripped)
-                result = Core.eval(Main, expr)
-            end
-        end
 
         return (success=true, result=result, error=nothing)
     catch e
@@ -51,9 +24,9 @@ end
     check_answer(user_answer, expected_answer, question_type)
 
 Check if the user's answer matches the expected answer based on question type.
-Evaluates user code and checks if the result matches what we expect.
 """
-function check_answer(user_answer::String, expected_answer, question_type::Symbol)
+function check_answer(user_answer::AbstractString, expected_answer, question_type::Symbol)
+    user_answer = String(user_answer)
     if question_type == :exact
         return strip(user_answer) == strip(string(expected_answer))
     elseif question_type == :multiple_choice
@@ -64,56 +37,20 @@ function check_answer(user_answer::String, expected_answer, question_type::Symbo
             return false
         end
     elseif question_type == :code
-        # Use multi-statement evaluator to handle cases like: v = [10, 20, 30]; v[1]
-        eval_result = safe_eval_multi(user_answer)
+        eval_result = safe_eval(user_answer)
 
         if !eval_result.success
-            return (correct=false, message="Error: $(eval_result.error)", result=nothing, show_result=false)
+            return (correct=false, message="Error: $(eval_result.error)")
         end
 
         # Check if result matches expected
         if eval_result.result == expected_answer
-            return (correct=true, message="", result=eval_result.result, show_result=true)
-            # Special case: if expected answer is a type, check if they got the right type
-        elseif isa(expected_answer, Type) && typeof(eval_result.result) == Type && eval_result.result == expected_answer
-            return (correct=true, message="", result=eval_result.result, show_result=true)
-            # Check for approximate equality for floating point
-        elseif isa(expected_answer, AbstractFloat) && isa(eval_result.result, AbstractFloat)
-            if isapprox(eval_result.result, expected_answer, rtol=1e-6)
-                return (correct=true, message="", result=eval_result.result, show_result=true)
-            else
-                return (correct=false,
-                    message="Not quite. You got $(eval_result.result), but expected approximately $(expected_answer)",
-                    result=eval_result.result,
-                    show_result=true)
-            end
-            # Check if they just created a binding and need to access it
-        elseif isa(eval_result.result, Vector) && isa(expected_answer, Number)
-            # They might have just done the first step (creating the vector)
-            # Give them a helpful hint
-            return (correct=false,
-                message="Good start! You've created the vector. Now access the element as described in the question.",
-                result=eval_result.result,
-                show_result=true)
+            return (correct=true, message="")
         elseif typeof(eval_result.result) == typeof(expected_answer)
             # Right type but wrong value
-            return (correct=false,
-                message="Not quite. You got $(eval_result.result), but the expected answer is $(expected_answer)",
-                result=eval_result.result,
-                show_result=true)
+            return (correct=false, message="Not quite. You got $(eval_result.result), but the expected answer is $(expected_answer)")
         else
-            # Different type - provide context-aware message
-            result_type_str = typeof(eval_result.result)
-            expected_type_str = typeof(expected_answer)
-
-            msg = "Not quite. Your answer produced $(result_type_str)"
-
-            # Add helpful context
-            if isa(eval_result.result, Vector) && length(eval_result.result) > 0
-                msg *= ". Did you mean to access a specific element?"
-            end
-
-            return (correct=false, message=msg, result=eval_result.result, show_result=true)
+            return (correct=false, message="Your code produced $(eval_result.result) (type: $(typeof(eval_result.result)))")
         end
     end
 
@@ -125,7 +62,8 @@ end
 
 Execute code without returning or displaying the result. Used for setup code.
 """
-function execute_code_silently(code::String)
+function execute_code_silently(code::AbstractString)
+    code = String(code)
     try
         Core.eval(Main, Meta.parse(code))
         return true

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -1,4 +1,4 @@
-# Progress tracking functionality with reset capabilities
+# Progress tracking functionality
 
 function get_progress_dir()
     dir = joinpath(homedir(), ".swirl_julia", "progress")
@@ -42,35 +42,6 @@ function save_lesson_progress(progress::LessonProgress)
 end
 
 """
-    reset_lesson_progress(course_name, lesson_name)
-
-Reset progress for a specific lesson (unticks it and clears all progress).
-"""
-function reset_lesson_progress(course_name::String, lesson_name::String)
-    progress_file = get_progress_file(course_name, lesson_name)
-    if isfile(progress_file)
-        rm(progress_file)
-    end
-end
-
-"""
-    reset_course_progress(course_name)
-
-Reset progress for all lessons in a course.
-"""
-function reset_course_progress(course_name::String)
-    progress_dir = get_progress_dir()
-    safe_course = replace(course_name, r"[^a-zA-Z0-9_-]" => "_")
-
-    # Find all progress files for this course
-    for file in readdir(progress_dir)
-        if startswith(file, safe_course * "_") && endswith(file, ".progress")
-            rm(joinpath(progress_dir, file))
-        end
-    end
-end
-
-"""
     delete_progress()
 
 Delete all saved progress. Returns to a fresh start.
@@ -81,59 +52,8 @@ function delete_progress()
         for file in readdir(progress_dir)
             rm(joinpath(progress_dir, file))
         end
-        println("✓ All progress deleted")
+        println("âœ“ All progress deleted")
     else
         println("No progress to delete")
     end
-end
-
-"""
-    list_progress()
-
-List all saved progress across all courses and lessons.
-"""
-function list_progress()
-    progress_dir = get_progress_dir()
-
-    if !isdir(progress_dir) || isempty(readdir(progress_dir))
-        println("No saved progress found.")
-        return
-    end
-
-    println("\n📊 Your Progress:")
-    println("="^60)
-
-    progress_files = filter(f -> endswith(f, ".progress"), readdir(progress_dir))
-
-    # Group by course
-    courses = Dict{String,Vector{LessonProgress}}()
-
-    for file in progress_files
-        try
-            progress = deserialize(joinpath(progress_dir, file))
-            if !haskey(courses, progress.course_name)
-                courses[progress.course_name] = LessonProgress[]
-            end
-            push!(courses[progress.course_name], progress)
-        catch
-            # Skip corrupted files
-        end
-    end
-
-    # Display progress by course
-    for (course_name, lessons) in courses
-        println("\n📚 $course_name")
-        for lesson in lessons
-            status = lesson.completed ? "✓" : "⏳"
-            percentage = lesson.current_question > 0 ?
-                         round(Int, 100 * lesson.correct_answers / lesson.current_question) : 0
-            println("  [$status] $(lesson.lesson_name)")
-            if !lesson.completed
-                println("      Progress: Question $(lesson.current_question) | Score: $(lesson.correct_answers) correct")
-            else
-                println("      Completed! Score: $(lesson.correct_answers)")
-            end
-        end
-    end
-    println()
 end

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -1,18 +1,19 @@
-# Improved Lesson runner - handles interactive lesson flow with natural interaction
+# runner.jl — lesson runners + REPL handler (with lesson navigation and course selection)
+
+# ============================================================================
+# CLASSIC MODE (readline-based)
+# ============================================================================
 
 """
-    run_lesson(course_name, lesson)
+    run_lesson_classic_mode(course_name, lesson)
 
-Run an interactive lesson, tracking progress and providing feedback.
+Run an interactive lesson using classic readline mode (original implementation).
 """
-function run_lesson(course_name::String, lesson::Lesson)
+function run_lesson_classic_mode(course_name::String, lesson::Lesson)
     println("\n" * "="^60)
     println("| $(lesson.name)")
     println("="^60)
     println(lesson.description)
-    println()
-    println("💡 Available commands: 'hint' (get help), 'skip' (skip question),")
-    println("   'back' (return to menu), 'info' (show commands again)")
     println()
 
     progress = get_lesson_progress(course_name, lesson.name)
@@ -25,7 +26,8 @@ function run_lesson(course_name::String, lesson::Lesson)
         print("Do you want to restart? (yes/no): ")
         response = lowercase(strip(readline()))
         if response != "yes" && response != "y"
-            return
+            println("\n👋 Returning to lesson menu...")
+            return :no_restart
         end
         progress = LessonProgress(course_name, lesson.name)
         start_idx = 1
@@ -35,7 +37,7 @@ function run_lesson(course_name::String, lesson::Lesson)
     for (idx, question) in enumerate(lesson.questions[start_idx:end])
         actual_idx = start_idx + idx - 1
 
-        if !run_question(question, actual_idx, length(lesson.questions))
+        if !run_question_classic(question, actual_idx, length(lesson.questions))
             # User wants to exit
             progress.current_question = actual_idx
             save_lesson_progress(progress)
@@ -56,21 +58,22 @@ function run_lesson(course_name::String, lesson::Lesson)
     println("| 🎉 Congratulations!")
     println("="^60)
     println("You've completed $(lesson.name)!")
-    println("Score: $(progress.correct_answers)/$(length(lesson.questions))")
+    total_questions = count(q -> q.type != :message, lesson.questions)
+    println("Score: $(progress.correct_answers)/$total_questions")
     println()
+    return :completed
 end
 
 """
-    run_question(question, idx, total)
+    run_question_classic(question, idx, total)
 
-Run a single question and return true if successful, false if user wants to exit.
+Run a single question in classic mode.
 """
-function run_question(question::Question, idx::Int, total::Int)
+function run_question_classic(question::Question, idx::Int, total::Int)
     println("\n--- Question $idx of $total ---")
     println()
 
     if question.type == :message
-        # Just display information
         println(question.text)
         println()
         print("Press Enter to continue...")
@@ -78,11 +81,9 @@ function run_question(question::Question, idx::Int, total::Int)
         return true
     end
 
-    # Display the question
     println(question.text)
     println()
 
-    # Display choices for multiple choice
     if question.type == :multiple_choice && !isempty(question.choices)
         for (i, choice) in enumerate(question.choices)
             println("  $i. $choice")
@@ -90,7 +91,6 @@ function run_question(question::Question, idx::Int, total::Int)
         println()
     end
 
-    # Get user answer with attempts
     max_attempts = 3
     attempts = 0
 
@@ -105,51 +105,29 @@ function run_question(question::Question, idx::Int, total::Int)
 
         user_input = readline()
 
-        # Check for special commands
         if lowercase(strip(user_input)) in ["exit", "quit", "bye"]
             return false
-        elseif lowercase(strip(user_input)) in ["back", "menu", "main"]
-            println("⊳ Returning to course menu...")
-            return false
         elseif lowercase(strip(user_input)) in ["skip"]
-            println("⊳ Skipping this question...")
+            println("⏭ Skipping this question...")
             return true
-        elseif lowercase(strip(user_input)) in ["hint", "help", "?"]
+        elseif lowercase(strip(user_input)) in ["hint", "help"]
             if !isempty(question.hint)
                 println("💡 Hint: $(question.hint)")
             else
                 println("💡 No hint available for this question.")
             end
-            attempts -= 1  # Don't count hint requests as attempts
-            continue
-        elseif lowercase(strip(user_input)) in ["info", "commands"]
-            println("\n💡 Available commands:")
-            println("   'hint' or '?' - Get a hint for this question")
-            println("   'skip' - Skip this question and move to the next")
-            println("   'back' - Return to the lesson selection menu")
-            println("   'exit' - Save progress and quit Swirl")
-            println()
-            attempts -= 1  # Don't count info requests as attempts
+            attempts -= 1
             continue
         end
 
-        # Check the answer
         result = check_answer(user_input, question.answer, question.type)
 
         if question.type == :code && result isa NamedTuple
             if result.correct
-                # Show what their code evaluated to for transparency
-                if result.show_result && result.result !== nothing
-                    println(result.result)
-                end
-                println("✓ Correct!")
+                println("✓ Correct! $(question.type == :code ? "Great work!" : "")")
                 println()
                 return true
             else
-                # Show the evaluation result
-                if result.show_result && result.result !== nothing
-                    println(result.result)
-                end
                 println("✗ $(result.message)")
                 if attempts < max_attempts
                     println("Try again (attempt $(attempts+1)/$max_attempts, or type 'hint' for help):")
@@ -167,8 +145,7 @@ function run_question(question::Question, idx::Int, total::Int)
         end
     end
 
-    # Max attempts reached
-    println("\n⊳ The correct answer was: $(question.answer)")
+    println("\n⏭ The correct answer was: $(question.answer)")
     if !isempty(question.hint)
         println("💡 $(question.hint)")
     end
@@ -176,3 +153,577 @@ function run_question(question::Question, idx::Int, total::Int)
 
     return true
 end
+
+# ============================================================================
+# REPL MODE (ReplMaker-based with lesson and course navigation)
+# ============================================================================
+
+mutable struct ReplLessonState
+    course::Course
+    current_lesson_idx::Int
+    lesson::Lesson
+    progress::LessonProgress
+    current_question_idx::Int
+    current_attempts::Int
+    max_attempts::Int
+    waiting_for_message::Bool
+    waiting_for_menu_choice::Bool
+    lesson_complete::Bool
+    waiting_for_restart_confirmation::Bool
+    was_previously_completed::Bool
+    waiting_for_reset_all_confirmation::Bool
+end
+
+mutable struct ReplCourseState
+    courses::Vector{Course}
+    waiting_for_course_choice::Bool
+end
+
+const CURRENT_LESSON_STATE = Ref{Any}(nothing)
+const REPL_MODE_INITIALIZED = Ref(false)
+
+"""
+    run_lesson_repl_mode(course_name, lesson)
+
+Run an interactive lesson using ReplMaker REPL mode with syntax highlighting.
+"""
+function run_lesson_repl_mode(course_name::String, lesson::Lesson)
+    # Get the full course to enable navigation
+    course = nothing
+    for c in get_available_courses()
+        if c.name == course_name
+            course = c
+            break
+        end
+    end
+
+    if course === nothing
+        error("Course not found: $course_name")
+    end
+
+    # Find lesson index
+    lesson_idx = findfirst(l -> l.name == lesson.name, course.lessons)
+    if lesson_idx === nothing
+        error("Lesson not found in course")
+    end
+
+    println("\n" * "="^60)
+    println("| $(lesson.name)")
+    println("="^60)
+    println(lesson.description)
+    println()
+
+    progress = get_lesson_progress(course_name, lesson.name)
+    start_idx = progress.completed ? 1 : progress.current_question
+
+    if progress.completed
+        state = ReplLessonState(
+            course,
+            lesson_idx,
+            lesson,
+            progress,
+            start_idx,
+            0,
+            3,
+            false,
+            false,
+            false,
+            true,  # waiting_for_restart_confirmation
+            true,  # was_previously_completed
+            false  # waiting_for_reset_all_confirmation
+        )
+        CURRENT_LESSON_STATE[] = state
+
+        println("You've already completed this lesson!")
+        println("Restart it? (Type 'yes' or 'no')")
+        println()
+        return true
+    end
+
+    # Initialize lesson state with course info
+    state = ReplLessonState(
+        course,
+        lesson_idx,
+        lesson,
+        progress,
+        start_idx,
+        0,      # current_attempts
+        3,      # max_attempts
+        false,  # waiting_for_message
+        false,  # waiting_for_menu_choice
+        false,  # lesson_complete
+        false,  # waiting_for_restart_confirmation
+        false,  # was_previously_completed
+        false   # waiting_for_reset_all_confirmation
+    )
+    CURRENT_LESSON_STATE[] = state
+
+    display_question(state)
+
+    return true
+end
+
+"""
+    display_question(state)
+"""
+function display_question(state::ReplLessonState)
+    if state.current_question_idx > length(state.lesson.questions)
+        return
+    end
+
+    question = state.lesson.questions[state.current_question_idx]
+
+    println("\n--- Question $(state.current_question_idx) of $(length(state.lesson.questions)) ---")
+    println()
+
+    if question.type == :message
+        println(question.text)
+        println()
+        # Automatically advance after message - no need to wait for input
+        state.waiting_for_message = false
+
+        # Check if this is the last question and complete if so
+        if state.current_question_idx >= length(state.lesson.questions)
+            state.current_question_idx += 1
+            state.progress.current_question = state.current_question_idx
+            save_lesson_progress(state.progress)
+
+            state.progress.completed = true
+            save_lesson_progress(state.progress)
+            state.lesson_complete = true
+
+            println("\n" * "="^60)
+            println("| 🎉 Congratulations!")
+            println("="^60)
+            println("You've completed $(state.lesson.name)!")
+            total_questions = count(q -> q.type != :message, state.lesson.questions)
+            println("Score: $(state.progress.correct_answers)/$total_questions")
+            println()
+
+            display_lesson_menu(state)
+        end
+    else
+        println(question.text)
+        println()
+
+        if question.type == :multiple_choice && !isempty(question.choices)
+            for (i, choice) in enumerate(question.choices)
+                println("  $i. $choice")
+            end
+            println()
+        end
+
+        state.waiting_for_message = false
+    end
+
+    state.current_attempts = 0
+end
+
+"""
+    display_lesson_menu(state)
+"""
+function display_lesson_menu(state::ReplLessonState)
+    println("\n" * "="^60)
+    println("Lessons in $(state.course.name):")
+    println("="^60)
+    for (i, lesson) in enumerate(state.course.lessons)
+        progress = get_lesson_progress(state.course.name, lesson.name)
+        status = progress.completed ? "✓" : " "
+        current = (i == state.current_lesson_idx) ? " ← just completed" : ""
+        println("  $i. [$status] $(lesson.name)$current")
+    end
+    println()
+    println("Commands:")
+    println("  0. Back to course selection")
+    println(" -1. Exit Swirl")
+    println("  reset <number> - Reset a specific lesson (e.g., 'reset 1')")
+    println("  reset all - Reset all lessons in this course")
+    println()
+    println("💡 Type a lesson number or command:")
+    state.waiting_for_menu_choice = true
+end
+
+"""
+    display_course_menu(courses)
+"""
+function display_course_menu(courses::Vector{Course})
+    println("\nAvailable courses:")
+    for (i, course) in enumerate(courses)
+        println("  $i. $(course.name)")
+    end
+    println(" -1. Exit Swirl")
+    println()
+    println("💡 Select a course (enter number):")
+end
+
+"""
+    swirl_repl_handler(input)
+"""
+function swirl_repl_handler(input::AbstractString)
+    input = String(strip(input))
+    state = CURRENT_LESSON_STATE[]
+
+    # Handle course selection mode
+    if state isa ReplCourseState
+        if input == ""
+            # Empty input in course selection, just wait
+            return nothing
+        end
+
+        try
+            choice = parse(Int, input)
+            if choice == -1
+                println("\n👋 Goodbye! Press backspace to exit Swirl mode and return to Julia.")
+                CURRENT_LESSON_STATE[] = nothing
+                return nothing
+            elseif choice >= 1 && choice <= length(state.courses)
+                selected_course = state.courses[choice]
+                # Show lesson menu for selected course
+                # Create a temporary lesson state for menu display
+                first_lesson = selected_course.lessons[1]
+                lesson_state = ReplLessonState(
+                    selected_course,
+                    1,
+                    first_lesson,
+                    LessonProgress(selected_course.name, first_lesson.name),
+                    1,
+                    0,
+                    3,
+                    false,
+                    true,  # waiting_for_menu_choice
+                    false,
+                    false,
+                    false,
+                    false  # waiting_for_reset_all_confirmation
+                )
+                CURRENT_LESSON_STATE[] = lesson_state
+                display_lesson_menu(lesson_state)
+                return nothing
+            else
+                println("Invalid choice. Enter a number between -1 and $(length(state.courses))")
+            end
+        catch
+            println("Invalid input. Please enter a number.")
+        end
+        return nothing
+    end
+
+    # Rest of handler for lesson state
+    if state === nothing
+        # State cleared, silently wait for user to exit
+        return nothing
+    end
+    @assert state isa ReplLessonState
+
+    # Handle restart confirmation
+    if state.waiting_for_restart_confirmation
+        response = lowercase(strip(input))
+        if response == "yes" || response == "y"
+            # Reset progress and start from beginning
+            state.progress = LessonProgress(state.course.name, state.lesson.name)
+            state.current_question_idx = 1
+            state.waiting_for_restart_confirmation = false
+
+            println("\n" * "="^60)
+            println("| $(state.lesson.name)")
+            println("="^60)
+            println(state.lesson.description)
+            println()
+
+            display_question(state)
+        elseif response == "no" || response == "n"
+            println("\n👋 Returning to lesson menu...")
+            state.waiting_for_restart_confirmation = false
+            state.waiting_for_menu_choice = true
+            display_lesson_menu(state)
+        else
+            println("Please type 'yes' or 'no'")
+        end
+        return nothing
+    end
+
+    # Handle reset all confirmation
+    if state.waiting_for_reset_all_confirmation
+        response = lowercase(strip(input))
+        if response == "yes" || response == "y"
+            count = 0
+            for lesson in state.course.lessons
+                progress_file = get_progress_file(state.course.name, lesson.name)
+                if isfile(progress_file)
+                    rm(progress_file)
+                    count += 1
+                end
+            end
+            println("✓ Reset $count lesson$(count == 1 ? "" : "s")")
+            state.waiting_for_reset_all_confirmation = false
+            state.waiting_for_menu_choice = true
+            display_lesson_menu(state)
+        else
+            println("Cancelled.")
+            state.waiting_for_reset_all_confirmation = false
+            state.waiting_for_menu_choice = true
+            display_lesson_menu(state)
+        end
+        return nothing
+    end
+
+    # Message-type questions - check this EARLY
+    if state.waiting_for_message
+        advance_to_next_question(state)
+        return nothing
+    end
+
+    # Display first question when entering REPL mode with empty input
+    if input == "" && !state.waiting_for_menu_choice && !state.lesson_complete
+        display_question(state)
+        return nothing
+    end
+
+    # Handle lesson menu selection
+    if state.waiting_for_menu_choice
+        # Check for reset commands first (before trying to parse as number)
+        if startswith(lowercase(input), "reset all")
+            handle_reset_all_repl(state)
+            return nothing
+        elseif startswith(lowercase(input), "reset ")
+            handle_reset_lesson_repl(state, input)
+            return nothing
+        end
+
+        try
+            choice = parse(Int, input)
+            if choice == -1
+                println("\n👋 Goodbye! Press backspace to exit Swirl mode and return to Julia.")
+                CURRENT_LESSON_STATE[] = nothing
+                return nothing
+            elseif choice == 0
+                # Go back to course selection
+                courses = get_available_courses()
+                course_state = ReplCourseState(courses, true)
+                CURRENT_LESSON_STATE[] = course_state
+                display_course_menu(courses)
+                return nothing
+            elseif choice >= 1 && choice <= length(state.course.lessons)
+                # Load new lesson
+                new_lesson = state.course.lessons[choice]
+                new_progress = get_lesson_progress(state.course.name, new_lesson.name)
+
+                # Update state for new lesson
+                state.current_lesson_idx = choice
+                state.lesson = new_lesson
+                state.progress = new_progress
+                state.current_question_idx = new_progress.completed ? 1 : new_progress.current_question
+                state.lesson_complete = false
+                state.waiting_for_menu_choice = false
+                state.was_previously_completed = new_progress.completed
+
+                if new_progress.completed
+                    println("\nYou've already completed this lesson!")
+                    println("Restart it? (yes/no): ")
+                    state.waiting_for_restart_confirmation = true
+                    return nothing
+                end
+
+                println("\n" * "="^60)
+                println("| $(new_lesson.name)")
+                println("="^60)
+                println(new_lesson.description)
+                println()
+
+                display_question(state)
+            else
+                println("Invalid choice. Enter a number between -1 and $(length(state.course.lessons))")
+            end
+        catch
+            println("Invalid input. Please enter a number or command (e.g., 'reset 1').")
+        end
+        return nothing
+    end
+
+    if state.lesson_complete
+        if lowercase(input) in ["exit", "quit", "bye"]
+            println("\n👋 Goodbye! Press backspace to exit Swirl mode and return to Julia.")
+            CURRENT_LESSON_STATE[] = nothing
+        end
+        return nothing
+    end
+
+    # Commands
+    low = lowercase(input)
+    if low == "hint" || low == "help"
+        handle_hint(state)
+        return nothing
+    end
+    if low == "skip"
+        handle_skip(state)
+        return nothing
+    end
+    if low == "restart"
+        handle_restart(state)
+        return nothing
+    end
+    if low in ["exit", "quit", "bye"]
+        handle_exit(state)
+        return nothing
+    end
+    if low == "menu"
+        println("\n💾 Saving progress and returning to lesson menu...")
+        state.progress.current_question = state.current_question_idx
+
+        # If this lesson was previously completed, restore that status
+        if state.was_previously_completed
+            state.progress.completed = true
+        end
+
+        save_lesson_progress(state.progress)
+        state.lesson_complete = false
+        state.waiting_for_menu_choice = true
+        display_lesson_menu(state)
+        return nothing
+    end
+
+    # Process answer
+    process_answer(state, input)
+    return nothing
+end
+
+function handle_hint(state::ReplLessonState)
+    q = state.lesson.questions[state.current_question_idx]
+    if !isempty(q.hint)
+        println("💡 Hint: $(q.hint)")
+    else
+        println("💡 No hint available for this question.")
+    end
+end
+
+function handle_reset_lesson_repl(state::ReplLessonState, input::AbstractString)
+    # Parse lesson number from "reset 1", "reset 2", etc.
+    parts = split(input)
+    if length(parts) >= 2
+        try
+            lesson_num = parse(Int, parts[2])
+            if lesson_num >= 1 && lesson_num <= length(state.course.lessons)
+                lesson = state.course.lessons[lesson_num]
+
+                # Delete progress file
+                progress_file = get_progress_file(state.course.name, lesson.name)
+                if isfile(progress_file)
+                    rm(progress_file)
+                    println("✓ Reset lesson: $(lesson.name)")
+                else
+                    println("ℹ️  Lesson not started yet: $(lesson.name)")
+                end
+                # Refresh the menu display
+                display_lesson_menu(state)
+            else
+                println("Invalid lesson number. Enter a number between 1 and $(length(state.course.lessons))")
+            end
+        catch
+            println("Invalid format. Use: reset <number> (e.g., 'reset 1')")
+        end
+    else
+        println("Invalid format. Use: reset <number> (e.g., 'reset 1')")
+    end
+end
+
+function handle_reset_all_repl(state::ReplLessonState)
+    println("Are you sure you want to reset ALL lessons in $(state.course.name)?")
+    println("Type 'yes' to confirm or anything else to cancel:")
+    state.waiting_for_reset_all_confirmation = true
+    state.waiting_for_menu_choice = false
+end
+
+function handle_skip(state::ReplLessonState)
+    println("⏭ Skipping this question...")
+    advance_to_next_question(state)
+end
+
+function handle_restart(state::ReplLessonState)
+    println("\n🔄 Restarting lesson...")
+    state.current_question_idx = 1
+    state.progress = LessonProgress(state.course.name, state.lesson.name)
+    state.lesson_complete = false
+    display_question(state)
+end
+
+function handle_exit(state::ReplLessonState)
+    state.progress.current_question = state.current_question_idx
+    save_lesson_progress(state.progress)
+    println("\n💾 Progress saved!")
+    println("👋 Press backspace to exit Swirl mode. Run swirl() to continue later.")
+    state.lesson_complete = true
+    CURRENT_LESSON_STATE[] = nothing
+end
+
+function process_answer(state::ReplLessonState, input::AbstractString)
+    input = String(input)
+    q = state.lesson.questions[state.current_question_idx]
+    state.current_attempts += 1
+
+    result = check_answer(input, q.answer, q.type)
+
+    if q.type == :code && result isa NamedTuple
+        if result.correct
+            println("✓ Correct! $(q.type == :code ? "Great work!" : "")")
+            println()
+            state.progress.correct_answers += 1
+            advance_to_next_question(state)
+        else
+            println("✗ $(result.message)")
+            handle_incorrect_answer(state)
+        end
+    elseif result == true || (result isa Bool && result)
+        println("✓ Correct!")
+        println()
+        state.progress.correct_answers += 1
+        advance_to_next_question(state)
+    else
+        println("✗ Not quite right.")
+        handle_incorrect_answer(state)
+    end
+end
+
+function handle_incorrect_answer(state::ReplLessonState)
+    if state.current_attempts < state.max_attempts
+        rem = state.max_attempts - state.current_attempts
+        println("Try again (attempt $(state.current_attempts+1)/$(state.max_attempts), or type 'hint' for help):")
+    else
+        q = state.lesson.questions[state.current_question_idx]
+        println("\n⏭ The correct answer was: $(q.answer)")
+        if !isempty(q.hint)
+            println("💡 $(q.hint)")
+        end
+        println()
+        advance_to_next_question(state)
+    end
+end
+
+function advance_to_next_question(state::ReplLessonState)
+    state.current_question_idx += 1
+    state.progress.current_question = state.current_question_idx
+    save_lesson_progress(state.progress)
+
+    if state.current_question_idx > length(state.lesson.questions)
+        # Lesson completed!
+        state.progress.completed = true
+        save_lesson_progress(state.progress)
+        state.lesson_complete = true
+
+        println("\n" * "="^60)
+        println("| 🎉 Congratulations!")
+        println("="^60)
+        println("You've completed $(state.lesson.name)!")
+        total_questions = count(q -> q.type != :message, state.lesson.questions)
+        println("Score: $(state.progress.correct_answers)/$total_questions")
+        println()
+
+        # Automatically show the menu
+        display_lesson_menu(state)
+    else
+        display_question(state)
+    end
+end
+
+# Backward-compatibility aliases
+const run_lesson = run_lesson_classic_mode
+const run_question = run_question_classic

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,7 +9,7 @@ mutable struct Question
     answer::Any
     hint::String
     choices::Vector{String}  # For multiple choice
-    validator::Union{Function, Nothing}  # Custom validation function
+    validator::Union{Function,Nothing}  # Custom validation function
 end
 
 Question(text, type, answer, hint="") = Question(text, type, answer, hint, String[], nothing)
@@ -44,5 +44,6 @@ mutable struct LessonProgress
     attempts::Int
 end
 
-LessonProgress(course::String, lesson::String) = 
+LessonProgress(course::String, lesson::String) =
     LessonProgress(course, lesson, 1, false, 0, 0)
+


### PR DESCRIPTION
# Swirl.jl — API & Behavior Changes (Breaking Release)

## TL;DR

- `swirl()` now runs in a **ReplMaker-powered interactive REPL** by default and can accept a keyword `use_repl_mode` to allow for setting either a **ReplMaker-powered interactive REPL** or a **classic readline mode**.
- Several functions were **removed from the public API** (breaking change).
- The **parser and progress system** were simplified.
- The **classic mode** remains available for backward compatibility.

Here is a short [demo video](https://youtu.be/_gOWw0_fi-E) showing the new REPL mode in action!

---

## 🌀 What’s New

### 1. ReplMaker Integration (Optional at Runtime)

Swirl can now run in a fully interactive REPL mode with syntax highlighting, color, completion, and (command history) navigation.

- **New dependency:** `ReplMaker` (added under `[deps]` in `Project.toml`).
- **Automatic installation:** Users do *not* need to install it manually — it is installed automatically when Swirl is added.
- **Safe fallback:** During initialization, Swirl checks if `ReplMaker` loads (or insatalled) successfully.  
  If not (e.g. in headless CI, broken environment, or custom sysimage), it automatically falls back to the **classic mode** instead of throwing an error.

This guarantees Swirl always works — with or without `ReplMaker`.

---

### 2. New Entry Point Signature

`swirl` now accepts an optional keyword argument:

```julia
swirl(; use_repl_mode = :auto)
```

Available options:

| Mode        | Description |
|--------------|--------------|
| `:auto` (default) | Use the swirl mode supported by ReplMaker if available/successfully installed, otherwise fallback to classic mode. |
| `:repl` | Force REPL mode. Errors if ReplMaker not available. |
| `:classic` | Force the classic readline mode (identical to previous behavior). |

Example:

```julia
using Swirl

swirl()  # auto-detect swirl/ReplMaker mode
swirl(; use_repl_mode = :classic)  # classic mode only
swirl(; use_repl_mode = :repl)     # force swirl/ReplMaker mode
julia> # type ')' and you enter the swirl> mode
```

---

### 3. In-REPL Course and Lesson Navigation

- You can now stay entirely inside the REPL for lesson progress, hints, and navigation.
- New REPL commands:
  ```
  hint     → show detailed hint
  skip     → skip current question
  restart  → restart lesson
  menu     → return to menu
  exit     → exit swirl mode
  ```
- Lesson reset commands:
  ```
  reset 3    → reset lesson #3
  reset all  → reset all lessons in current course
  ```

These are implemented through new REPL state types and handlers.

---

### 4. Classic Mode Still Available

The previous “readline” flow is preserved and can be explicitly requested with:

```julia
swirl(; use_repl_mode = :classic)
```

Aliases `run_lesson` and `run_question` continue to point to the classic implementations for full backward compatibility.

---

### 5. Refactored Menus and Lesson Flow

The codebase was refactored for clarity and maintainability:

- New helpers:
  - `course_selection_menu`
  - `lesson_selection_loop`
  - `handle_reset_lesson`
  - `handle_reset_all`
  - `run_lesson_with_mode`
- Cleaner separation between UI logic and evaluation logic.

---

### 6. Lesson Title Update

The lesson formerly titled **“Basic Math and Variables”** is now **“Basic Math and Bindings”**, aligning with Julia terminology.

---

## ⚠️ Breaking Changes

### A. Removed Exports

The following functions are no longer exported (or part of the documented API):

- `reset_lesson_progress`
- `reset_course_progress`
- `list_progress`
- `list_installed_courses`

Use the new **REPL commands** or call `delete_progress()` to clear all progress.

---

### B. Reset Logic Refactored

- Reset functionality is now handled **inside the menu system**.
- Programmatic resets (via `reset_*` functions) are no longer public.

To delete all user progress manually:
```julia
Swirl.delete_progress()
```

---

### C. Parser Simplification

- `safe_eval_multi` was **removed**.
- `safe_eval` now accepts `AbstractString` inputs and can handle semicolons/newlines directly.
  ```julia
  safe_eval("x = 10; y = 5; x + y")
  ```
- The evaluation logic is safer and more consistent, maintaining variables in `Main`.

---

## ✅ How to Adapt

| Old Behavior | New Equivalent |
|---------------|----------------|
| `reset_lesson_progress()` | Use menu command `reset <n>` |
| `reset_course_progress()` | Use menu command `reset all` |
| `list_progress()` | Check progress from the menu |
| `safe_eval_multi()` | Use `safe_eval()` directly |
| `swirl()` (no args) | Works as before, now with optional REPL mode |

---

## 🧠 Why Keep the Fallback?

Even though `ReplMaker` is a declared dependency (and will install automatically):

- It may **fail to precompile or load** in certain environments.
- A fallback keeps Swirl functional everywhere.

This defensive design ensures Swirl doesn’t break even if `ReplMaker` does.

---

## 📘 Summary Table

| Category | Change | Impact |
|-----------|---------|--------|
| API | Removed reset and listing functions | **Breaking** |
| Function signature | `swirl(; use_repl_mode=:auto)` | **Breaking (if called positionally)** |
| Dependency | Added `ReplMaker` | None (auto-installed) |
| Parser | Removed `safe_eval_multi` | **Breaking** |
| Lessons | Renamed first lesson | Cosmetic |
| REPL UX | Added interactive commands | Major improvement |

---

## 🪄 Migration Checklist

- [ ] Remove usage of `reset_lesson_progress` or `reset_course_progress`.
- [ ] Replace `safe_eval_multi` with `safe_eval`.
- [ ] If you had automation scripts calling `swirl()` directly, verify positional arguments still work.
- [ ] Test the new REPL-based interaction (type `)` to enter swirl mode, Backspace to exit).

---

## 🗒️ Version Note

These changes will be introduced as the **next minor release (v0.1 → v0.5)**  
and are **breaking** for anyone relying on the removed API.

---

## 🙋 Feedback

If you encounter issues or want to extend REPL mode (e.g. new commands or color themes), open a discussion or issue on:

👉 **https://github.com/atantos/Swirl.jl**
